### PR TITLE
Updated the Game Page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,9 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1"
+gem 'actioncable', '~> 7.0'
+
 gem 'haml-rails', '~> 2.0'
 
 # This is for 3rd-party login(Google login in this case)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,10 @@ GEM
       ffi (~> 1.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
@@ -513,6 +517,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  actioncable (~> 7.0)
   bcrypt (~> 3.1.7)
   bootsnap
   bootstrap (~> 5.3.3)
@@ -538,6 +543,7 @@ DEPENDENCIES
   rails (~> 7.2.0)
   rails-controller-testing
   rails_12factor
+  redis (>= 4.0.1)
   rspec (~> 3.5)
   rspec-expectations
   rspec-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -191,3 +191,81 @@ $body-color: $text-default;
 .profile-picture-container img:hover {
   transform: scale(1.1); /* Slight zoom effect */
 }
+
+// Game page styling
+.game-container {
+  .sidebar {
+    width: 300px;
+  }
+
+  .gpt-response {
+    overflow-y: auto;
+  }
+
+  .content-area {
+    .gpt-image-box {
+      position: relative;
+      width: 75%;  // Smaller width
+      height: 75%; // Matching height
+      margin: 0 auto;
+      background-color: #ecf0f1;
+  
+      .square-container {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        background-color: #ecf0f1;
+        color: #7f8c8d;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        }
+      
+  
+      button#map_button {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 1;
+      }
+  
+      img {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+  
+      p {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+    }
+  
+    .user-input {
+      margin-top: auto;
+    }
+  }
+  
+}
+
+.grid-map {
+  width: 100%;
+  height: 100%;
+  display: grid;
+}
+
+.tile {
+  border: 1px solid #ccc;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #ecf0f1;
+  }
+}

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -44,8 +44,8 @@ class Game < ApplicationRecord
 
   def generate_tiles
     rows, columns = map_size.split('x').map(&:to_i)
-    (1..rows).each do |x|
-      (1..columns).each do |y|
+    (0..rows).each do |x|
+      (0..columns).each do |y|
         tiles.create!(
           x_coordinate: x,
           y_coordinate: y,

--- a/app/views/games/_map.html.haml
+++ b/app/views/games/_map.html.haml
@@ -1,0 +1,27 @@
+- tiles = game.tiles
+- game_users = game.game_users.includes(:user, :current_tile)
+- rows, columns = game.map_size.split('x').map(&:to_i)
+- grid_style = "grid-template-columns: repeat(#{columns}, 1fr); grid-template-rows: repeat(#{rows}, 1fr);"
+
+%div.grid-map{ style: "#{grid_style};" }
+  - tile_hash = tiles.index_by { |t| [t.x_coordinate, t.y_coordinate] }
+  - player_positions = {}
+  - game_users.each do |gu|
+    - if gu.current_tile.present?
+      - key = [gu.current_tile.x_coordinate, gu.current_tile.y_coordinate]
+      - player_positions[key] ||= []
+      - player_positions[key] << gu
+  - (0...rows).each do |y|
+    - (0...columns).each do |x|
+      - tile = tile_hash[[x, y]]
+      - tile_classes = 'tile d-flex align-items-center justify-content-center'
+      - tile_content = ''
+      - if tile
+        - tile_content = tile.tile_type.capitalize
+        - if player_positions[[x, y]]
+          - players = player_positions[[x, y]].map { |gu| gu.user.name }.join(', ')
+          - tile_content += " (#{players})"
+      - else
+        - tile_content = 'Unknown'
+      %div{ class: tile_classes }
+        = tile_content

--- a/app/views/games/map.js.erb
+++ b/app/views/games/map.js.erb
@@ -1,0 +1,4 @@
+const modalBody = document.querySelector('#mapModal .modal-body');
+if (modalBody) {
+  modalBody.innerHTML = '<%= j(render partial: "map", locals: { game: @game, tiles: @tiles, game_users: @game_users }) %>';
+}

--- a/app/views/games/new.html.haml
+++ b/app/views/games/new.html.haml
@@ -17,4 +17,4 @@
   .actions
     = form.submit "Create Game"
 
-= link_to 'Back', landing_path
+-# = link_to 'Back', landing_path

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -1,17 +1,86 @@
 = render 'shared/flash'
+%section.game-container.d-flex.h-100.overflow-hidden
+  / Sidebar
+  %aside.sidebar.bg-dark.text-white.p-3.d-flex.flex-column
+    
 
-%h1= @game.name
+    %h2.mb-3 Game Info
+    %p
+      %strong Game Name:
+      = @game.name
+    %p
+      %strong Join Code:
+      = @game.join_code
+    %p
+      %strong Current Turn:
+      - if @game.current_turn_user
+        = @game.current_turn_user.name
+      - else
+        Not started
 
-%p
-  %strong Join Code:
-  = @game.join_code
+    %h3.mt-4 Players
+    %ul
+      - @game_users.each do |game_user|
+        %li= "#{game_user.user.name} (Health: #{game_user.health})"
 
-%h2 Players
-%ul
-  - @game_users.each do |game_user|
-    %li= "#{game_user.user.name} (Health: #{game_user.health})"
+    %button#inventory_button.btn.btn-secondary.mt-3{ "data-bs-toggle" => "modal", "data-bs-target" => "#inventoryModal" }
+      Inventory
+    
+    = link_to 'Back to Landing Page', landing_path
 
-- if @game.owner == @current_user
-  = link_to 'Start Game', start_game_path(@game), class: 'btn btn-success'
+    / GPT Response Field
+    %div.gpt-response.bg-secondary.text-white.p-3.mt-4.flex-grow-1.overflow-auto
+      %h4 GPT Response
+      %p#chatbot-response.mb-0
+        -# Placeholder for GPT response text
+        No response yet.
 
-= link_to 'Back to Landing Page', landing_path
+  / Main Content Area
+  %main.content-area.flex-grow-1.p-3.d-flex.flex-column
+    / GPT Image Placeholder
+    %div.gpt-image-box.position-relative.mb-3.bg-light
+      %button#map_button.btn.btn-primary.position-absolute.top-0.end-0.m-2{ "data-bs-toggle" => "modal", "data-bs-target" => "#mapModal" }
+        View Map
+      %div.square-container.d-flex.align-items-center.justify-content-center
+        %p.text-muted.mb-0 GPT-generated images will appear here.
+
+    / Editable User Input Field
+    %div.user-input.mt-3
+      = form_with url: '#', local: true do |form|
+        .mb-3
+          = form.label :message, 'Your Response', class: 'form-label fw-bold'
+          = form.text_area :message, id: 'user-message', class: 'form-control', rows: 3, placeholder: 'Type your message here...'
+        = form.submit 'Send', class: 'btn btn-primary'
+
+  / Map Modal
+  .modal.fade#mapModal{ tabindex: "-1", "aria-labelledby" => "mapModalLabel", "aria-hidden" => "true" }
+    .modal-dialog.modal-lg
+      .modal-content
+        .modal-header
+          %h5#mapModalLabel.modal-title Map
+          %button.btn-close{ type: "button", "data-bs-dismiss" => "modal", "aria-label" => "Close" }
+        .modal-body
+          = render partial: 'map', locals: { game: @game, tiles: @tiles, game_users: @game_users }
+
+        .modal-footer
+          %button.btn.btn-secondary{ type: "button", "data-bs-dismiss" => "modal" } Close
+
+  / Inventory Modal
+  .modal.fade#inventoryModal{ tabindex: "-1", "aria-labelledby" => "inventoryModalLabel", "aria-hidden" => "true" }
+    .modal-dialog
+      .modal-content
+        .modal-header
+          %h5#inventoryModalLabel.modal-title Inventory
+          %button.btn-close{ type: "button", "data-bs-dismiss" => "modal", "aria-label" => "Close" }
+        .modal-body
+          / Inventory Items
+          - current_game_user = @game_users.find_by(user: @current_user)
+          - if current_game_user && current_game_user.equipment.present?
+            %ul
+              - current_game_user.equipment.each do |item|
+                %li= item
+          - else
+            %p No items in your inventory.
+        .modal-footer
+          %button.btn.btn-secondary{ type: "button", "data-bs-dismiss" => "modal" } Close
+

--- a/app/views/landing/index.html.haml
+++ b/app/views/landing/index.html.haml
@@ -54,7 +54,7 @@
         - game_object = @game || Game.new
         = form_with model: game_object, url: games_path, local: true do |form|
           .modal-header
-            %h5.modal-title#createGameModalLabel{ style: "color: black;" } Create a New Game
+            %h5.modal-title#createGameModalLabel{ style: "color: black;" } Create a New Game (Costs 500 Shards!)
             %button.btn-close{ type: "button", "data-bs-dismiss" => "modal", "aria-label" => "Close" }
           .modal-body
             - if game_object.errors.any?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
     %title My Application
     = stylesheet_link_tag 'application'
-    = javascript_include_tag 'application'
     = csrf_meta_tags
+    = javascript_importmap_tags
     %link{href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css", rel: "stylesheet"}
     %script{src: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"}
   %body{ style: "margin: 0; padding: 0; height: 100%; width: 100%;" }

--- a/features/player_name.feature
+++ b/features/player_name.feature
@@ -1,0 +1,21 @@
+Feature: Displaying player profile name in the game
+
+  As a player,
+  I want my profile name to show in the game,
+  So that other players know who I am.
+
+  Background:
+    Given the following users exist:
+      | name        | email            | password    |
+      | ExampleUser | user@example.com | oldpassword |
+      | TestUser    | test@example.com | testpass    |
+    And I am logged in as "user@example.com" with password "oldpassword"
+
+  Scenario: Player's profile name is displayed in the game
+    Given a game exists for joining with join code "A1B2C3"
+    When I navigate to the landing page
+    And I click on the "Join Game" button
+    And I fill in "join_game_join_code" with "A1B2C3"
+    And I submit the join game form
+    Then I should see "You have successfully joined the game."
+    And my profile name "ExampleUser" should be displayed in the game lobby

--- a/features/step_definitions/join_game_steps.rb
+++ b/features/step_definitions/join_game_steps.rb
@@ -12,3 +12,7 @@ When("I submit the join game form") do
     click_button "Join Game"
   end
 end
+
+Then('my profile name {string} should be displayed in the game lobby') do |string|
+  expect(page).to have_content(string)
+end


### PR DESCRIPTION
# Add Game Info Page and Popup Modal for Map Grid

## Summary of Changes

1. **Game Info Page:**
   - Added a dedicated **Game Info** page showing:
     - Game name, join code, and current player's turn.
     - List of players in the game lobby, including health details.
     - **Inventory** button for accessing player inventory.
   - Added a **GPT Response** and **GPT Image** placeholder.
   - Added **User Input** placeholder for later communicating with GPT

2. **Map Grid Popup:**
   - Implemented a **View Map** button that triggers a modal displaying the game map grid.
   - Map shows terrain details for each tile (e.g., grassland).

3. **Known Issue:**
   - Player list doesn't auto-update—requires page refresh for now.

### Images:

- **Game Info Page:**

  
![image](https://github.com/user-attachments/assets/55e98eeb-9183-418c-9d5d-e001afd66998)


- **Map Grid Modal:**

  
![image](https://github.com/user-attachments/assets/12049d5a-a1d2-48c7-ae5b-3e493dc63e33)


## Notes

- These changes enhance game visibility and navigation within the lobby.
- Next steps: Add live player list and map location updates

#27 