### PR TITLE
Fixed issue where friends would not show up in the list to add to a g…

### DIFF
--- a/app/views/landing/index.html.haml
+++ b/app/views/landing/index.html.haml
@@ -57,7 +57,7 @@
                     %button.btn-close{ type: "button", "data-bs-dismiss" => "modal", "aria-label" => "Close" }
                   %div.modal-body
                     = form_with url: invite_friends_game_path(game), method: :post, local: true do |f|
-                      - @friends = @current_user.friends
+                      - @friends = @current_user.friends + @current_user.inverse_friends
                       - @friends_in_game = game.users
                       - available_friends = @friends - @friends_in_game
                       - if available_friends.empty?

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -630,7 +630,7 @@
           null,
           null,
           1,
-          13,
+          17,
           null,
           null,
           5,
@@ -834,7 +834,7 @@
         "branches": {}
       }
     },
-    "timestamp": 1732872735
+    "timestamp": 1732901478
   },
   "Cucumber Features": {
     "coverage": {
@@ -863,7 +863,7 @@
           null,
           null,
           1,
-          41,
+          75,
           null,
           null,
           22,
@@ -1670,6 +1670,6 @@
         ]
       }
     },
-    "timestamp": 1732872751
+    "timestamp": 1732901499
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2024-11-29T03:32:31-06:00">2024-11-29T03:32:31-06:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2024-11-29T11:31:39-06:00">2024-11-29T11:31:39-06:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -29,7 +29,7 @@
      covered at
      <span class="covered_strength">
        <span class="green">
-         34.32
+         34.41
        </span>
     </span> hits/line
     )
@@ -263,7 +263,7 @@
             <td class="cell--number">52</td>
             <td class="cell--number">52</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">45.75</td>
+            <td class="cell--number">46.48</td>
             
           </tr>
         
@@ -501,7 +501,7 @@
      covered at
      <span class="covered_strength">
        <span class="green">
-         82.55
+         82.86
        </span>
     </span> hits/line
     )
@@ -614,7 +614,7 @@
             <td class="cell--number">52</td>
             <td class="cell--number">52</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">45.75</td>
+            <td class="cell--number">46.48</td>
             
           </tr>
         
@@ -9010,9 +9010,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="54" data-linenumber="24">
+          <li class="covered" data-hits="92" data-linenumber="24">
             
-              <span class="hits">54</span>
+              <span class="hits">92</span>
             
 
             

--- a/features/step_definitions/invite_friends_steps.rb
+++ b/features/step_definitions/invite_friends_steps.rb
@@ -9,7 +9,6 @@ Given('I have the following friends:') do |table|
     end
     # Create mutual friendships
     Friendship.create!(user: @current_user, friend: friend, status: 'accepted')
-    Friendship.create!(user: friend, friend: @current_user, status: 'accepted')
   end
 end
 


### PR DESCRIPTION
### **Fix friend addition system for inviting friends to games**

---

### Description:  
This pull request resolves an issue where friends were not properly listed when inviting them to join a game. The problem occurred because only direct friends were being included, excluding mutual or inverse friends. The fix ensures that both `friends` and `inverse_friends` are correctly accounted for in the list of available friends.

#### Changes Made:
1. Updated the logic in `app/views/landing/index.html.haml` to include `@current_user.inverse_friends` in the list of friends displayed.
2. Adjusted coverage metadata in `coverage/.resultset.json` to reflect recent test results.
3. Updated the generated timestamp and metrics in `coverage/index.html` for the updated coverage report.
4. Removed redundant mutual friendship creation logic in `features/step_definitions/invite_friends_steps.rb`.

---

### Testing:
- Verified that friends and inverse friends are displayed correctly in the invite modal.
- Ensured that only friends not already part of the game are shown in the available friends list.
- Confirmed that tests pass with the updated logic.

---

### Closing Issues:

Closes #99 

---